### PR TITLE
feat: discovery api

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/core/AasRepository.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/core/AasRepository.java
@@ -19,6 +19,7 @@ import de.fraunhofer.iosb.ilt.faaast.registry.core.exception.ResourceNotFoundExc
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
 
 
@@ -53,6 +54,17 @@ public interface AasRepository {
      * @throws ResourceNotFoundException if the requested resource does not exist
      */
     public AssetAdministrationShellDescriptor getAAS(String aasId) throws ResourceNotFoundException;
+
+
+    /**
+     * Retrieves the Asset Administration Shells with the given SpecificAssetIDs. *All* of the SpecificAssetIds must match.
+     *
+     * @param specificAssetIds The SpecificAssetIDs of the desired Asset Administration Shells. If a specificAssetId is a
+     *            globalAssetId according to AASd-116, it is treated as the globalAssetId of the desired Asset
+     *            Administration Shells.
+     * @return The desired Asset Administration Shells.
+     */
+    public List<AssetAdministrationShellDescriptor> getAAS(List<SpecificAssetId> specificAssetIds);
 
 
     /**
@@ -133,7 +145,8 @@ public interface AasRepository {
      * @throws ResourceNotFoundException if the aas does not exist
      * @throws ResourceAlreadyExistsException if the submodel already exists
      */
-    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException, ResourceAlreadyExistsException;
+    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException,
+            ResourceAlreadyExistsException;
 
 
     /**

--- a/persistence/jpa/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/jpa/AasRepositoryJpa.java
+++ b/persistence/jpa/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/jpa/AasRepositoryJpa.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
 import org.springframework.stereotype.Repository;
 
@@ -62,6 +63,18 @@ public class AasRepositoryJpa extends AbstractAasRepository {
         AssetAdministrationShellDescriptor aas = fetchAAS(aasId);
         Ensure.requireNonNull(aas, buildAASNotFoundException(aasId));
         return aas;
+    }
+
+
+    @Override
+    public List<AssetAdministrationShellDescriptor> getAAS(List<SpecificAssetId> specificAssetIds) {
+        Ensure.requireNonNull(specificAssetIds, "specificAssetIds must be non-null");
+
+        List<AssetAdministrationShellDescriptor> shellDescriptors = EntityManagerHelper.getAll(entityManager,
+                JpaAssetAdministrationShellDescriptor.class,
+                AssetAdministrationShellDescriptor.class);
+
+        return filterAssetAdministrationShellDescriptors(shellDescriptors, specificAssetIds);
     }
 
 
@@ -140,7 +153,8 @@ public class AasRepositoryJpa extends AbstractAasRepository {
 
 
     @Override
-    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException, ResourceAlreadyExistsException {
+    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException,
+            ResourceAlreadyExistsException {
         ensureAasId(aasId);
         ensureDescriptorId(descriptor);
         AssetAdministrationShellDescriptor aas = fetchAAS(aasId);

--- a/persistence/memory/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/memory/AasRepositoryMemory.java
+++ b/persistence/memory/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/memory/AasRepositoryMemory.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
 
 
@@ -65,6 +66,14 @@ public class AasRepositoryMemory extends AbstractAasRepository {
         AssetAdministrationShellDescriptor aas = fetchAAS(id);
         Ensure.requireNonNull(aas, buildAASNotFoundException(id));
         return aas;
+    }
+
+
+    @Override
+    public List<AssetAdministrationShellDescriptor> getAAS(List<SpecificAssetId> specificAssetIds) {
+        Ensure.requireNonNull(specificAssetIds, "specificAssetIds must be non-null");
+
+        return filterAssetAdministrationShellDescriptors(shellDescriptors.values(), specificAssetIds);
     }
 
 
@@ -137,7 +146,8 @@ public class AasRepositoryMemory extends AbstractAasRepository {
 
 
     @Override
-    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException, ResourceAlreadyExistsException {
+    public SubmodelDescriptor addSubmodel(String aasId, SubmodelDescriptor descriptor) throws ResourceNotFoundException,
+            ResourceAlreadyExistsException {
         ensureAasId(aasId);
         ensureDescriptorId(descriptor);
         AssetAdministrationShellDescriptor aas = fetchAAS(aasId);

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/DiscoveryController.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/DiscoveryController.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.registry.service;
+
+import de.fraunhofer.iosb.ilt.faaast.registry.core.exception.BadRequestException;
+import de.fraunhofer.iosb.ilt.faaast.registry.core.exception.ResourceNotFoundException;
+import de.fraunhofer.iosb.ilt.faaast.registry.service.helper.Constants;
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
+import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
+import de.fraunhofer.iosb.ilt.faaast.service.util.FaaastConstants;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSpecificAssetId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+
+/**
+ * REST controller for the Submodel registry.
+ */
+@RestController
+@RequestMapping(value = Constants.DISCOVERY_PATH)
+public class DiscoveryController {
+
+    @Autowired
+    RegistryService service;
+
+    /**
+     * Returns a list of Asset Administration Shell ids linked to specific Asset identifiers.
+     *
+     * @param assetIds A list of AssetLinks that all shall match. An AssetLink might be either derived from a
+     *            SpecificAssetId ("name": "'specificAssetId.name'", "value": "'specificAssetId.value'")
+     *            or a globalAssetId ("name": "globalAssetId", "value": "'globalAssetId-value'").
+     * @param limit The maximum number of elements in the response array. minimum: 1
+     * @param cursor The cursor value.
+     * @return Requested Asset Administration Shell ids.
+     */
+    @GetMapping("")
+    public Page<String> getAllAssetAdministrationShellIdsBySpecificAssetIds(
+                                                                            // Default Value is a b64URL-encoded '[]'
+                                                                            @RequestParam(name = "assetIds", required = false, defaultValue = "W10") List<SpecificAssetId> assetIds,
+                                                                            @RequestParam(name = "limit", required = false) Long limit,
+                                                                            @RequestParam(name = "cursor", required = false) String cursor) {
+
+        PagingInfo pagingInfo = PagingInfo.builder()
+                .cursor(cursor)
+                .limit(limit == null ? PagingInfo.DEFAULT_LIMIT : limit)
+                .build();
+
+        return service.getAASIdsBySpecificAssetId(assetIds, pagingInfo);
+    }
+
+
+    /**
+     * Returns a list of specific asset identifiers based on an Asset Administration Shell ID to edit discoverable content.
+     * The global asset ID is returned as specific asset ID with "name" equal to "globalAssetId" (see Constraint AASd-116).
+     *
+     * @param aasIdentifier The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded).
+     * @return Requested specific Asset identifiers.
+     */
+    @GetMapping("/{aasIdentifier}")
+    public List<SpecificAssetId> getAllAssetLinksById(
+                                                      @PathVariable(name = "aasIdentifier") String aasIdentifier)
+            throws ResourceNotFoundException {
+        AssetAdministrationShellDescriptor selectedDescriptor = service.getAAS(aasIdentifier);
+
+        List<SpecificAssetId> result = new ArrayList<>(selectedDescriptor.getSpecificAssetIds());
+        if (Objects.nonNull(selectedDescriptor.getGlobalAssetId())) {
+            result.add(new DefaultSpecificAssetId.Builder()
+                    .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                    .value(selectedDescriptor.getGlobalAssetId())
+                    .build());
+        }
+
+        return result;
+    }
+
+
+    /**
+     * Returns a list of specific asset identifiers based on an Asset Administration Shell ID to edit discoverable content.
+     * The global asset ID is returned as specific asset ID with "name" equal to "globalAssetId" (see Constraint AASd-116).
+     *
+     * @param aasIdentifier The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded).
+     * @return Requested specific Asset identifiers.
+     */
+    @PostMapping("/{aasIdentifier}")
+    public ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(
+                                                                       @PathVariable(name = "aasIdentifier") String aasIdentifier,
+                                                                       @RequestBody List<SpecificAssetId> specificAssetIds)
+            throws ResourceNotFoundException {
+        AssetAdministrationShellDescriptor selectedDescriptor = service.getAAS(aasIdentifier);
+
+        List<SpecificAssetId> globalKeys = specificAssetIds.stream()
+                .filter(x -> FaaastConstants.KEY_GLOBAL_ASSET_ID.equals(x.getName()))
+                .toList();
+
+        if (!globalKeys.isEmpty()) {
+            if (globalKeys.size() == 1 && globalKeys.get(0) != null) {
+                selectedDescriptor.setGlobalAssetId(globalKeys.get(0).getValue());
+            }
+            else {
+                throw new BadRequestException(String.format("%s must be unique in the specificAssetIds but was found %s times.",
+                        FaaastConstants.KEY_GLOBAL_ASSET_ID,
+                        globalKeys.size()));
+            }
+        }
+
+        specificAssetIds.removeAll(globalKeys);
+
+        List<SpecificAssetId> updatedSpecificAssetIds = selectedDescriptor.getSpecificAssetIds();
+
+        specificAssetIds.forEach(specificAssetId -> {
+            var existing = updatedSpecificAssetIds.stream()
+                    .filter(id -> Objects.equals(specificAssetId.getName(), id.getName()))
+                    .toList();
+            if (existing.size() == 1) {
+                updatedSpecificAssetIds.remove(existing.get(0));
+            }
+            else if (existing.size() > 1) {
+                throw new BadRequestException(String.format("Name %s must be unique in the specificAssetIds but was found %s times.",
+                        specificAssetId.getName(), existing.size()));
+            }
+            updatedSpecificAssetIds.add(specificAssetId);
+        });
+
+        service.updateAAS(aasIdentifier, selectedDescriptor);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path(String.format("/%s", EncodingHelper.base64UrlEncode(selectedDescriptor.getId())))
+                .build().toUri();
+
+        List<SpecificAssetId> result = selectedDescriptor.getSpecificAssetIds();
+        if (selectedDescriptor.getGlobalAssetId() != null) {
+            SpecificAssetId globalAssetIdAsSpecificAssetId = new DefaultSpecificAssetId.Builder()
+                    .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                    .value(selectedDescriptor.getGlobalAssetId())
+                    .build();
+
+            result.add(globalAssetIdAsSpecificAssetId);
+        }
+
+        return ResponseEntity.created(location).body(result);
+    }
+
+
+    /**
+     * Returns a list of specific asset identifiers based on an Asset Administration Shell ID to edit discoverable content.
+     * The global asset ID is returned as specific asset ID with "name" equal to "globalAssetId" (see Constraint AASd-116).
+     *
+     * @param aasIdentifier The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded).
+     * @return Requested specific Asset identifiers.
+     */
+    @DeleteMapping("/{aasIdentifier}")
+    public ResponseEntity<Void> deleteAllAssetLinksById(
+                                                        @PathVariable(name = "aasIdentifier") String aasIdentifier)
+            throws ResourceNotFoundException {
+        AssetAdministrationShellDescriptor selectedDescriptor = service.getAAS(aasIdentifier);
+        selectedDescriptor.getSpecificAssetIds().clear();
+        selectedDescriptor.setGlobalAssetId(null);
+
+        service.updateAAS(aasIdentifier, selectedDescriptor);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryControllerAdvice.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryControllerAdvice.java
@@ -25,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentConversionNotSupportedException;
 
 
 /**
@@ -70,14 +71,13 @@ public class RegistryControllerAdvice {
                 HttpStatus.CONFLICT);
     }
 
-
     /**
-     * Handles BadRequestException.
+     * Handles BadRequestException and MethodArgumentConversionNotSupportedException.
      *
      * @param e The desired exception.
      * @return The corresponding response.
      */
-    @ExceptionHandler(BadRequestException.class)
+    @ExceptionHandler({ BadRequestException.class, MethodArgumentConversionNotSupportedException.class })
     public ResponseEntity<Result> handleBadRequestException(Exception e) {
         return new ResponseEntity<>(
                 new DefaultResult.Builder()
@@ -96,6 +96,7 @@ public class RegistryControllerAdvice {
      * @param e The desired exception.
      * @return The corresponding response.
      */
+    @ExceptionHandler(Exception.class)
     public ResponseEntity<Result> handleExceptions(Exception e) {
         return new ResponseEntity<>(
                 new DefaultResult.Builder()

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryControllerAdvice.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryControllerAdvice.java
@@ -71,13 +71,17 @@ public class RegistryControllerAdvice {
                 HttpStatus.CONFLICT);
     }
 
+
     /**
      * Handles BadRequestException and MethodArgumentConversionNotSupportedException.
      *
      * @param e The desired exception.
      * @return The corresponding response.
      */
-    @ExceptionHandler({ BadRequestException.class, MethodArgumentConversionNotSupportedException.class })
+    @ExceptionHandler({
+            BadRequestException.class,
+            MethodArgumentConversionNotSupportedException.class
+    })
     public ResponseEntity<Result> handleBadRequestException(Exception e) {
         return new ResponseEntity<>(
                 new DefaultResult.Builder()

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryService.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/RegistryService.java
@@ -326,7 +326,12 @@ public class RegistryService {
     private static <T> Page<T> preparePagedResult(List<T> input, PagingInfo paging) {
         Stream<T> result = input.stream();
         if (Objects.nonNull(paging.getCursor())) {
-            long skip = readCursor(paging.getCursor());
+            long skip;
+            try {
+                skip = readCursor(paging.getCursor());
+            } catch (NumberFormatException e) {
+                throw new BadRequestException(String.format("invalid cursor (cursor: %s)", paging.getCursor()), e);
+            }
             if (skip < 0 || skip >= input.size()) {
                 throw new BadRequestException(String.format("invalid cursor (cursor: %s)", paging.getCursor()));
             }

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/config/ControllerConfig.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/config/ControllerConfig.java
@@ -16,6 +16,7 @@ package de.fraunhofer.iosb.ilt.faaast.registry.service.config;
 
 import de.fraunhofer.iosb.ilt.faaast.registry.service.helper.AssetKindConverter;
 import de.fraunhofer.iosb.ilt.faaast.registry.service.helper.Constants;
+import de.fraunhofer.iosb.ilt.faaast.registry.service.helper.SpecificAssetIdListConverter;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -104,6 +105,7 @@ public class ControllerConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new AssetKindConverter());
+        registry.addConverter(new SpecificAssetIdListConverter());
     }
 
 

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/Constants.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/Constants.java
@@ -22,6 +22,7 @@ public final class Constants {
     public static final String SHELL_REQUEST_PATH = "/shell-descriptors";
     public static final String SUBMODEL_REQUEST_PATH = "/submodel-descriptors";
     public static final String DESCRIPTION_REQUEST_PATH = "/description";
+    public static final String DISCOVERY_PATH = "/lookup/shells";
 
     private Constants() {}
 }

--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/SpecificAssetIdListConverter.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/SpecificAssetIdListConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.registry.service.helper;
+
+import de.fraunhofer.iosb.ilt.faaast.registry.core.exception.BadRequestException;
+import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonDeserializer;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Converts an incoming HTTP request parameter into a list of SpecificAssetIds.
+ */
+public class SpecificAssetIdListConverter implements Converter<String, List<SpecificAssetId>> {
+
+    private final JsonDeserializer jsonDeserializer = new JsonDeserializer();
+
+    @Override
+    public List<SpecificAssetId> convert(@Nonnull String source) {
+        try {
+            return jsonDeserializer.readList(EncodingHelper.base64UrlDecode(source), SpecificAssetId.class);
+        }
+        catch (DeserializationException | IllegalArgumentException e) {
+            throw new BadRequestException(e);
+        }
+    }
+}

--- a/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/AbstractShellRegistryControllerIT.java
+++ b/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/AbstractShellRegistryControllerIT.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.registry.service;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
+import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
+import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
+import org.eclipse.digitaltwin.aas4j.v3.model.SecurityTypeEnum;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAdministrativeInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultDataSpecificationIec61360;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEmbeddedDataSpecification;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEndpoint;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultExtension;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringDefinitionTypeIec61360;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringNameType;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringPreferredNameTypeIec61360;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringShortNameTypeIec61360;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringTextType;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProtocolInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSecurityAttributeObject;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueList;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueReferencePair;
+import org.junit.Assert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+
+public abstract class AbstractShellRegistryControllerIT {
+
+    private final String baseResourceName;
+
+    public AbstractShellRegistryControllerIT(String baseResourceName) {
+        this.baseResourceName = baseResourceName;
+    }
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    protected void createAas(AssetAdministrationShellDescriptor aas) {
+        HttpEntity<AssetAdministrationShellDescriptor> entity = new HttpEntity<>(aas);
+        ResponseEntity<AssetAdministrationShellDescriptor> responsePost = restTemplate.exchange("http://localhost:" + port + "/api/v3" +
+                ".0/shell-descriptors", HttpMethod.POST, entity,
+                AssetAdministrationShellDescriptor.class);
+        Assert.assertNotNull(responsePost);
+        Assert.assertEquals(HttpStatus.CREATED, responsePost.getStatusCode());
+        Assert.assertEquals(aas, responsePost.getBody());
+    }
+
+
+    protected String createURLWithPort(String uri) {
+        return "http://localhost:" + port + "/api/v3.0" + baseResourceName + uri;
+    }
+
+
+    protected static AssetAdministrationShellDescriptor getAas() {
+        return new DefaultAssetAdministrationShellDescriptor.Builder()
+                .idShort("IntegrationTest99")
+                .id("http://iosb.fraunhofer.de/IntegrationTest/AAS99")
+                .displayName(new DefaultLangStringNameType.Builder().text("Integration Test 99 Name").language("de-DE").build())
+                .description(new DefaultLangStringTextType.Builder()
+                        .language("en-US")
+                        .text("AAS 99 Integration Test")
+                        .build())
+                .description(new DefaultLangStringTextType.Builder()
+                        .language("de-DE")
+                        .text("AAS 99 Integrationstest")
+                        .build())
+                .globalAssetId("http://iosb.fraunhofer.de/GlobalAssetId/IntegrationTest99")
+                .assetType("AssetType99")
+                .assetKind(AssetKind.INSTANCE)
+                .administration(new DefaultAdministrativeInformation.Builder()
+                        .creator(new DefaultReference.Builder()
+                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                .keys(new DefaultKey.Builder()
+                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                        .value("http://anydomain.com/users/User99-1")
+                                        .build())
+                                .build())
+                        .version("12")
+                        .revision("25")
+                        .embeddedDataSpecifications(new DefaultEmbeddedDataSpecification.Builder()
+                                .dataSpecification(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/AAS99/DataSpecificationIEC61360")
+                                                .build())
+                                        .build())
+                                .dataSpecificationContent(new DefaultDataSpecificationIec61360.Builder()
+                                        .preferredName(Arrays.asList(
+                                                new DefaultLangStringPreferredNameTypeIec61360.Builder().text("AAS 99 Spezifikation").language("de").build(),
+                                                new DefaultLangStringPreferredNameTypeIec61360.Builder().text("AAS 99 Specification").language("en" +
+                                                        "-us").build()))
+                                        .dataType(DataTypeIec61360.REAL_MEASURE)
+                                        .definition(new DefaultLangStringDefinitionTypeIec61360.Builder().text("Dies ist eine Data Specification " +
+                                                "fuer Integration Test")
+                                                .language("de").build())
+                                        .definition(
+                                                new DefaultLangStringDefinitionTypeIec61360.Builder().text("This is a DataSpecification for " +
+                                                        "integration testing purposes")
+                                                        .language("en-us").build())
+                                        .shortName(new DefaultLangStringShortNameTypeIec61360.Builder().text("Test Spezifikation").language("de").build())
+                                        .shortName(new DefaultLangStringShortNameTypeIec61360.Builder().text("Test Spec").language("en-us").build())
+                                        .unit("SpaceUnit")
+                                        .unitId(new DefaultReference.Builder()
+                                                .keys(new DefaultKey.Builder()
+                                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Units/TestUnit")
+                                                        .build())
+                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                                .build())
+                                        .sourceOfDefinition("http://iosb.fraunhofer.de/IntegrationTest/AAS99/DataSpec/ExampleDef")
+                                        .symbol("SU")
+                                        .valueFormat("string")
+                                        .value("TEST")
+                                        .valueList(new DefaultValueList.Builder()
+                                                .valueReferencePairs(new DefaultValueReferencePair.Builder()
+                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId")
+                                                        .valueId(new DefaultReference.Builder()
+                                                                .keys(new DefaultKey.Builder()
+                                                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ExampleValueId")
+                                                                        .build())
+                                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                                                .build())
+                                                        .build())
+                                                .valueReferencePairs(new DefaultValueReferencePair.Builder()
+                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId2")
+                                                        .valueId(new DefaultReference.Builder()
+                                                                .keys(new DefaultKey.Builder()
+                                                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId2")
+                                                                        .build())
+                                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .endpoints(new DefaultEndpoint.Builder()
+                        ._interface("http")
+                        .protocolInformation(new DefaultProtocolInformation.Builder()
+                                .endpointProtocol("http")
+                                .href("http://iosb.fraunhofer.de/IntegrationTest/Endpoints/AAS99")
+                                .endpointProtocolVersion(List.of("2.1"))
+                                .subprotocol("https")
+                                .subprotocolBody("any body")
+                                .subprotocolBodyEncoding("UTF-8")
+                                .securityAttributes(new DefaultSecurityAttributeObject.Builder()
+                                        .type(SecurityTypeEnum.NONE)
+                                        .key("")
+                                        .value("")
+                                        .build())
+                                .build())
+                        .build())
+                .extensions(new DefaultExtension.Builder()
+                        .name("AAS99 Extension Name")
+                        .value("AAS99 Extension Value")
+                        .semanticId(new DefaultReference.Builder()
+                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                .keys(new DefaultKey.Builder()
+                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SemanticId1")
+                                        .build())
+                                .build())
+                        .refersTo(new DefaultReference.Builder()
+                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                .keys(new DefaultKey.Builder()
+                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/RefersTo1")
+                                        .build())
+                                .build())
+                        .valueType(DataTypeDefXsd.STRING)
+                        .supplementalSemanticIds(new DefaultReference.Builder()
+                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                .keys(new DefaultKey.Builder()
+                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SupplementalSemanticId1")
+                                        .build())
+                                .build())
+                        .build())
+                .submodelDescriptors(new DefaultSubmodelDescriptor.Builder()
+                        .id("http://iosb.fraunhofer.de/IntegrationTest/Submodel99-1")
+                        .idShort("Submodel-99-1")
+                        .administration(new DefaultAdministrativeInformation.Builder()
+                                .version("1")
+                                .revision("12")
+                                .build())
+                        .semanticId(new DefaultReference.Builder()
+                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                .keys(new DefaultKey.Builder()
+                                        .type(KeyTypes.GLOBAL_REFERENCE)
+                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Submodel99-1/SemanticId")
+                                        .build())
+                                .build())
+                        .endpoints(new DefaultEndpoint.Builder()
+                                ._interface("http")
+                                .protocolInformation(new DefaultProtocolInformation.Builder()
+                                        .endpointProtocol("http")
+                                        .href("http://iosb.fraunhofer.de/Endpoints/Submodel99-1")
+                                        .endpointProtocolVersion(List.of("2.0"))
+                                        .build())
+                                .build())
+                        .build())
+                .specificAssetIds(
+                        new DefaultSpecificAssetId.Builder()
+                                .name("DefaultSpecificAssetId-1 Name")
+                                .value("DefaultSpecificAssetId-1 Value")
+                                .supplementalSemanticIds(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SupplementalSemanticId1")
+                                                .build())
+                                        .build())
+                                .semanticId(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/DefaultSpecificAssetId-1/SemanticId")
+                                                .build())
+                                        .build())
+                                .externalSubjectId(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/DefaultSpecificAssetId-1/ExternalSubjectId")
+                                                .build())
+                                        .build())
+                                .build())
+                .specificAssetIds(
+                        new DefaultSpecificAssetId.Builder()
+                                .name("DefaultSpecificAssetId-2 Name")
+                                .value("DefaultSpecificAssetId-2 Value")
+                                .supplementalSemanticIds(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SupplementalSemanticId2")
+                                                .build())
+                                        .build())
+                                .semanticId(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/DefaultSpecificAssetId-2/SemanticId")
+                                                .build())
+                                        .build())
+                                .externalSubjectId(new DefaultReference.Builder()
+                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
+                                        .keys(new DefaultKey.Builder()
+                                                .type(KeyTypes.GLOBAL_REFERENCE)
+                                                .value("http://iosb.fraunhofer.de/IntegrationTest/DefaultSpecificAssetId-2/ExternalSubjectId")
+                                                .build())
+                                        .build())
+                                .build())
+                .build();
+    }
+
+}

--- a/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/DiscoveryControllerIT.java
+++ b/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/DiscoveryControllerIT.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.registry.service;
+
+import static de.fraunhofer.iosb.ilt.faaast.registry.service.helper.Constants.DISCOVERY_PATH;
+
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
+import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
+import de.fraunhofer.iosb.ilt.faaast.service.util.FaaastConstants;
+import java.util.List;
+import java.util.UUID;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonSerializer;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSpecificAssetId;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = App.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations = "classpath:application-integrationtest.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class DiscoveryControllerIT extends AbstractShellRegistryControllerIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    public DiscoveryControllerIT() {
+        super(DISCOVERY_PATH);
+    }
+
+
+    @Test
+    public void getAllAssetLinksById_withUnknownAasIdentifier() {
+        String identifierB64 = EncodingHelper.base64UrlEncode("my-aas-identifier");
+        String urlWithPort = createURLWithPort(String.format("/%s", identifierB64));
+
+        ResponseEntity<Object> response = restTemplate.exchange(urlWithPort, HttpMethod.GET, null, Object.class);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+    }
+
+
+    @Test
+    public void getAllAssetLinksById_withKnownAasIdentifier() {
+        AssetAdministrationShellDescriptor descriptor = getAas();
+        createAas(descriptor);
+
+        String identifierB64 = EncodingHelper.base64UrlEncode(descriptor.getId());
+
+        String urlWithPort = createURLWithPort(String.format("/%s", identifierB64));
+
+        ResponseEntity<List<SpecificAssetId>> response = getAllAssetLinksById(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+
+        var expected = descriptor.getSpecificAssetIds();
+
+        if (descriptor.getGlobalAssetId() != null) {
+            expected.add(new DefaultSpecificAssetId.Builder()
+                    .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                    .value(descriptor.getGlobalAssetId())
+                    .build());
+        }
+
+        Assert.assertEquals(expected, response.getBody());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withNoInput() {
+        Page<String> expected = Page.of(List.of());
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(createURLWithPort(""));
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+        Assert.assertEquals(expected.getContent(), response.getBody().getContent());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withUnknownGlobalAssetId() throws SerializationException {
+        Page<String> expected = Page.of();
+
+        var mySpecificAssetIds = List.of(new DefaultSpecificAssetId.Builder()
+                .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                .value(UUID.randomUUID().toString()).build());
+
+        String serializedSpecificAssetIds = new JsonSerializer().write(mySpecificAssetIds);
+        String encodedSpecificAssetIds = EncodingHelper.base64UrlEncode(serializedSpecificAssetIds);
+
+        String urlWithPort = createURLWithPort(String.format("?assetIds=%s", encodedSpecificAssetIds));
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+        Assert.assertEquals(expected.getContent(), response.getBody().getContent());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withNoArguments() {
+        Page<String> expected = Page.of();
+
+        String urlWithPort = createURLWithPort("");
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+        Assert.assertEquals(expected.getContent(), response.getBody().getContent());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withMalformedLimit() {
+        String urlWithPort = createURLWithPort("?limit=-42");
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withMalformedCursor() {
+        String urlWithPort = createURLWithPort("?cursor=NonSensicalCursorArgument");
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+
+    @Test
+    public void getAllAssetAdministrationShellIdsBySpecificAssetIds_withMalformedSpecificAssetIds() {
+        String urlWithPort = createURLWithPort("?assetIds=NonSensicalArgument");
+
+        ResponseEntity<Page<String>> response = getAllAssetAdministrationShellIdsBySpecificAssetIds(urlWithPort);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+
+    @Test
+    public void postAllAssetLinksById_withNewGlobalAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode(shellDescriptor.getId())));
+
+        String newGlobalAssetId = UUID.randomUUID().toString();
+        List<SpecificAssetId> updatedSpecificAssetIds = List.of(new DefaultSpecificAssetId.Builder()
+                .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                .value(newGlobalAssetId)
+                .build());
+
+        ResponseEntity<List<SpecificAssetId>> response = postAllAssetLinksById(urlWithPort, updatedSpecificAssetIds);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+        Assert.assertNotNull(response.getBody());
+        Assert.assertEquals(newGlobalAssetId, response.getBody().stream()
+                .filter(id -> FaaastConstants.KEY_GLOBAL_ASSET_ID.equals(id.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getValue());
+        assertSameSpecificAssetIds(shellDescriptor, response.getBody());
+    }
+
+
+    @Test
+    public void postAllAssetLinksById_withUnknownAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode("unknown")));
+
+        String newGlobalAssetId = UUID.randomUUID().toString();
+        List<SpecificAssetId> updatedSpecificAssetIds = List.of(new DefaultSpecificAssetId.Builder()
+                .name(FaaastConstants.KEY_GLOBAL_ASSET_ID)
+                .value(newGlobalAssetId)
+                .build());
+
+        ResponseEntity<Object> response = restTemplate.exchange(urlWithPort, HttpMethod.POST, new HttpEntity<>(updatedSpecificAssetIds),
+                Object.class);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+    }
+
+
+    @Test
+    public void postAllAssetLinksById_withNewSpecificAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode(shellDescriptor.getId())));
+
+        SpecificAssetId newSpecificAssetId = new DefaultSpecificAssetId.Builder()
+                .name(UUID.randomUUID().toString())
+                .value(UUID.randomUUID().toString())
+                .build();
+
+        List<SpecificAssetId> updatedSpecificAssetIds = List.of(newSpecificAssetId);
+
+        ResponseEntity<List<SpecificAssetId>> response = postAllAssetLinksById(urlWithPort, updatedSpecificAssetIds);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+        Assert.assertNotNull(response.getBody());
+
+        Assert.assertEquals(1,
+                response.getBody().stream()
+                        .map(SpecificAssetId::getName)
+                        .filter(name -> newSpecificAssetId.getName().equals(name))
+                        .count());
+
+        Assert.assertTrue(response.getBody().contains(newSpecificAssetId));
+
+        assertSameGlobalAssetId(shellDescriptor, response.getBody());
+
+        Assert.assertEquals(shellDescriptor.getSpecificAssetIds(), response.getBody().stream()
+                .filter(id -> !FaaastConstants.KEY_GLOBAL_ASSET_ID.equals(id.getName()))
+                .filter(id -> !newSpecificAssetId.getName().equals(id.getName()))
+                .toList());
+    }
+
+
+    @Test
+    public void postAllAssetLinksById_withUpdatedSpecificAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode(shellDescriptor.getId())));
+
+        SpecificAssetId newSpecificAssetId = new DefaultSpecificAssetId.Builder()
+                .name(shellDescriptor.getSpecificAssetIds().stream().findAny().orElseThrow().getName())
+                .value(UUID.randomUUID().toString())
+                .build();
+
+        List<SpecificAssetId> updatedSpecificAssetIds = List.of(newSpecificAssetId);
+
+        ResponseEntity<List<SpecificAssetId>> response = postAllAssetLinksById(urlWithPort, updatedSpecificAssetIds);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+        Assert.assertNotNull(response.getBody());
+
+        Assert.assertEquals(1,
+                response.getBody().stream()
+                        .map(SpecificAssetId::getName)
+                        .filter(name -> newSpecificAssetId.getName().equals(name))
+                        .count());
+
+        Assert.assertTrue(response.getBody().contains(newSpecificAssetId));
+
+        Assert.assertEquals(newSpecificAssetId.getValue(),
+                response.getBody().stream()
+                        .filter(id -> newSpecificAssetId.getName().equals(id.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue());
+
+        assertSameGlobalAssetId(shellDescriptor, response.getBody());
+    }
+
+
+    @Test
+    public void deleteAllAssetLinksById_withKnownAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode(shellDescriptor.getId())));
+
+        // precondition: specific asset ids are not empty
+        ResponseEntity<List<SpecificAssetId>> preconditionResponse = getAllAssetLinksById(urlWithPort);
+
+        Assert.assertNotNull(preconditionResponse.getBody());
+        Assert.assertFalse(preconditionResponse.getBody().isEmpty());
+
+        ResponseEntity<Void> response = deleteAllAssetLinksById(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        // postcondition: no specific asset ids
+        ResponseEntity<List<SpecificAssetId>> postconditionResponse = getAllAssetLinksById(urlWithPort);
+
+        Assert.assertNotNull(postconditionResponse.getBody());
+        Assert.assertTrue(postconditionResponse.getBody().isEmpty());
+    }
+
+
+    @Test
+    public void deleteAllAssetLinksById_withUnknownAssetId() {
+        AssetAdministrationShellDescriptor shellDescriptor = getAas();
+        createAas(shellDescriptor);
+
+        String urlWithPort = createURLWithPort(String.format("/%s", EncodingHelper.base64UrlEncode("unknown")));
+        ResponseEntity<Void> response = deleteAllAssetLinksById(urlWithPort);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+
+    private void assertSameGlobalAssetId(AssetAdministrationShellDescriptor expected, List<SpecificAssetId> actual) {
+        Assert.assertEquals(expected.getGlobalAssetId(), actual.stream()
+                .filter(id -> FaaastConstants.KEY_GLOBAL_ASSET_ID.equals(id.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getValue());
+    }
+
+
+    private void assertSameSpecificAssetIds(AssetAdministrationShellDescriptor expected, List<SpecificAssetId> actual) {
+        Assert.assertEquals(expected.getSpecificAssetIds(), actual.stream()
+                .filter(id -> !FaaastConstants.KEY_GLOBAL_ASSET_ID.equals(id.getName())).toList());
+    }
+
+
+    private ResponseEntity<Page<String>> getAllAssetAdministrationShellIdsBySpecificAssetIds(String urlWithPort) {
+        return restTemplate.exchange(urlWithPort, HttpMethod.GET, null, new ParameterizedTypeReference<Page<String>>() {});
+    }
+
+
+    private ResponseEntity<List<SpecificAssetId>> getAllAssetLinksById(String urlWithPort) {
+        return restTemplate.exchange(urlWithPort, HttpMethod.GET, null, new ParameterizedTypeReference<List<SpecificAssetId>>() {});
+    }
+
+
+    private ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(String urlWithPort, List<SpecificAssetId> specificAssetIds) {
+        return restTemplate.exchange(urlWithPort, HttpMethod.POST, new HttpEntity<>(specificAssetIds),
+                new ParameterizedTypeReference<List<SpecificAssetId>>() {});
+    }
+
+
+    private ResponseEntity<Void> deleteAllAssetLinksById(String urlWithPort) {
+        return restTemplate.exchange(urlWithPort, HttpMethod.DELETE, null,
+                Void.class);
+    }
+}

--- a/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/ShellRegistryControllerIT.java
+++ b/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/ShellRegistryControllerIT.java
@@ -14,46 +14,27 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.registry.service;
 
+import static de.fraunhofer.iosb.ilt.faaast.registry.service.helper.Constants.SHELL_REQUEST_PATH;
+
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
 import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
-import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
-import org.eclipse.digitaltwin.aas4j.v3.model.SecurityTypeEnum;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAdministrativeInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShellDescriptor;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultDataSpecificationIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEmbeddedDataSpecification;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEndpoint;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultExtension;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringDefinitionTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringPreferredNameTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringShortNameTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultLangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProtocolInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSecurityAttributeObject;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelDescriptor;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueList;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueReferencePair;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -67,13 +48,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = App.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = "classpath:application-integrationtest.properties")
-public class ShellRegistryControllerIT {
-
-    @LocalServerPort
-    private int port;
-
-    @Autowired
-    private TestRestTemplate restTemplate;
+public class ShellRegistryControllerIT extends AbstractShellRegistryControllerIT {
 
     @Test
     public void testGetAASs() {
@@ -84,6 +59,11 @@ public class ShellRegistryControllerIT {
     @Test
     public void testGetAASsWithSlash() {
         assertGetAASs("/");
+    }
+
+
+    public ShellRegistryControllerIT() {
+        super(SHELL_REQUEST_PATH);
     }
 
 
@@ -131,14 +111,16 @@ public class ShellRegistryControllerIT {
         expected.getDisplayName().add(new DefaultLangStringNameType.Builder().text("Integration Test 100 Name Updated").language("en-US").build());
 
         HttpEntity<AssetAdministrationShellDescriptor> entity = new HttpEntity<>(expected);
-        ResponseEntity responsePut = restTemplate.exchange(createURLWithPort("/" + EncodingHelper.base64UrlEncode(expected.getId())), HttpMethod.PUT, entity, Void.class);
+        ResponseEntity responsePut = restTemplate.exchange(createURLWithPort(
+                "/" + EncodingHelper.base64UrlEncode(expected.getId())), HttpMethod.PUT, entity, Void.class);
         Assert.assertNotNull(responsePut);
         Assert.assertEquals(HttpStatus.NO_CONTENT, responsePut.getStatusCode());
 
         checkGetAas(expected);
 
         // delete AAS
-        ResponseEntity responseDelete = restTemplate.exchange(createURLWithPort("/" + EncodingHelper.base64UrlEncode(expected.getId())), HttpMethod.DELETE, entity, Void.class);
+        ResponseEntity responseDelete = restTemplate.exchange(createURLWithPort(
+                "/" + EncodingHelper.base64UrlEncode(expected.getId())), HttpMethod.DELETE, entity, Void.class);
         Assert.assertNotNull(responseDelete);
         Assert.assertEquals(HttpStatus.NO_CONTENT, responsePut.getStatusCode());
 
@@ -190,7 +172,9 @@ public class ShellRegistryControllerIT {
         expectedMap.remove(actual.getId());
 
         ResponseEntity<Page<AssetAdministrationShellDescriptor>> response2 = restTemplate.exchange(
-                createURLWithPort("?limit=1&assetType=" + EncodingHelper.base64UrlEncode(assetType) + "&cursor=" + metadata.getCursor()), HttpMethod.GET, null,
+                createURLWithPort(
+                        "?limit=1&assetType=" + EncodingHelper.base64UrlEncode(assetType) + "&cursor=" + metadata.getCursor()),
+                HttpMethod.GET, null,
                 new ParameterizedTypeReference<Page<AssetAdministrationShellDescriptor>>() {});
         Assert.assertNotNull(response2);
         Assert.assertEquals(HttpStatus.OK, response2.getStatusCode());
@@ -218,7 +202,8 @@ public class ShellRegistryControllerIT {
 
         // add Submodel
         HttpEntity<SubmodelDescriptor> entity = new HttpEntity<>(newSubmodel);
-        ResponseEntity<SubmodelDescriptor> responsePost = restTemplate.exchange(createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors"),
+        ResponseEntity<SubmodelDescriptor> responsePost = restTemplate.exchange(createURLWithPort(
+                "/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors"),
                 HttpMethod.POST, entity, SubmodelDescriptor.class);
         Assert.assertNotNull(responsePost);
         Assert.assertEquals(HttpStatus.CREATED, responsePost.getStatusCode());
@@ -231,7 +216,8 @@ public class ShellRegistryControllerIT {
         newSubmodel.getDescription().add(new DefaultLangStringTextType.Builder().language("en-US").text("Submodel 101-2 new Description").build());
         entity = new HttpEntity<>(newSubmodel);
         ResponseEntity responsePut = restTemplate.exchange(
-                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors/" + EncodingHelper.base64UrlEncode(newSubmodel.getId())),
+                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors/" +
+                        EncodingHelper.base64UrlEncode(newSubmodel.getId())),
                 HttpMethod.PUT, entity, Void.class);
         Assert.assertNotNull(responsePut);
         Assert.assertEquals(HttpStatus.NO_CONTENT, responsePut.getStatusCode());
@@ -239,7 +225,8 @@ public class ShellRegistryControllerIT {
 
         // delete Submodel
         ResponseEntity responseDelete = restTemplate.exchange(
-                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors/" + EncodingHelper.base64UrlEncode(newSubmodel.getId())),
+                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors/" +
+                        EncodingHelper.base64UrlEncode(newSubmodel.getId())),
                 HttpMethod.DELETE, null, Void.class);
         Assert.assertNotNull(responseDelete);
         Assert.assertEquals(HttpStatus.NO_CONTENT, responseDelete.getStatusCode());
@@ -254,7 +241,8 @@ public class ShellRegistryControllerIT {
         createAas(aas);
 
         HttpEntity<SubmodelDescriptor> entity = new HttpEntity<>(getSubmodelInvalid());
-        ResponseEntity responsePost = restTemplate.exchange(createURLWithPort("/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors"),
+        ResponseEntity responsePost = restTemplate.exchange(createURLWithPort(
+                "/" + EncodingHelper.base64UrlEncode(aas.getId()) + "/submodel-descriptors"),
                 HttpMethod.POST, entity, Void.class);
         Assert.assertNotNull(responsePost);
         Assert.assertEquals(HttpStatus.BAD_REQUEST, responsePost.getStatusCode());
@@ -263,7 +251,9 @@ public class ShellRegistryControllerIT {
 
     private void checkGetAas(AssetAdministrationShellDescriptor expected) {
         ResponseEntity<AssetAdministrationShellDescriptor> response = restTemplate.exchange(
-                createURLWithPort("/" + EncodingHelper.base64UrlEncode(expected.getId())), HttpMethod.GET, null, AssetAdministrationShellDescriptor.class);
+                createURLWithPort(
+                        "/" + EncodingHelper.base64UrlEncode(expected.getId())),
+                HttpMethod.GET, null, AssetAdministrationShellDescriptor.class);
         Assert.assertNotNull(response);
         Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
         Assert.assertNotNull(response.getBody());
@@ -281,7 +271,9 @@ public class ShellRegistryControllerIT {
 
     private void checkGetSubmodel(String aasId, SubmodelDescriptor submodel) {
         ResponseEntity<SubmodelDescriptor> response = restTemplate.exchange(
-                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aasId) + "/submodel-descriptors/" + EncodingHelper.base64UrlEncode(submodel.getId())), HttpMethod.GET, null,
+                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aasId) + "/submodel-descriptors/" +
+                        EncodingHelper.base64UrlEncode(submodel.getId())),
+                HttpMethod.GET, null,
                 SubmodelDescriptor.class);
         Assert.assertNotNull(response);
         Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -292,25 +284,12 @@ public class ShellRegistryControllerIT {
 
     private void checkGetSubmodelError(String aasId, String submodelId, HttpStatusCode statusCode) {
         ResponseEntity<SubmodelDescriptor> response = restTemplate.exchange(
-                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aasId) + "/submodel-descriptors/" + EncodingHelper.base64UrlEncode(submodelId)), HttpMethod.GET, null,
+                createURLWithPort("/" + EncodingHelper.base64UrlEncode(aasId) + "/submodel-descriptors/" +
+                        EncodingHelper.base64UrlEncode(submodelId)),
+                HttpMethod.GET, null,
                 SubmodelDescriptor.class);
         Assert.assertNotNull(response);
         Assert.assertEquals(statusCode, response.getStatusCode());
-    }
-
-
-    private String createURLWithPort(String uri) {
-        return "http://localhost:" + port + "/api/v3.0/shell-descriptors" + uri;
-    }
-
-
-    private void createAas(AssetAdministrationShellDescriptor aas) {
-        HttpEntity<AssetAdministrationShellDescriptor> entity = new HttpEntity<>(aas);
-        ResponseEntity<AssetAdministrationShellDescriptor> responsePost = restTemplate.exchange(createURLWithPort(""), HttpMethod.POST, entity,
-                AssetAdministrationShellDescriptor.class);
-        Assert.assertNotNull(responsePost);
-        Assert.assertEquals(HttpStatus.CREATED, responsePost.getStatusCode());
-        Assert.assertEquals(aas, responsePost.getBody());
     }
 
 
@@ -320,158 +299,6 @@ public class ShellRegistryControllerIT {
                 AssetAdministrationShellDescriptor.class);
         Assert.assertNotNull(responsePost);
         Assert.assertEquals(statusCode, responsePost.getStatusCode());
-    }
-
-
-    private static AssetAdministrationShellDescriptor getAas() {
-        return new DefaultAssetAdministrationShellDescriptor.Builder()
-                .idShort("IntegrationTest99")
-                .id("http://iosb.fraunhofer.de/IntegrationTest/AAS99")
-                .displayName(new DefaultLangStringNameType.Builder().text("Integration Test 99 Name").language("de-DE").build())
-                .description(new DefaultLangStringTextType.Builder()
-                        .language("en-US")
-                        .text("AAS 99 Integration Test")
-                        .build())
-                .description(new DefaultLangStringTextType.Builder()
-                        .language("de-DE")
-                        .text("AAS 99 Integrationstest")
-                        .build())
-                .globalAssetId("http://iosb.fraunhofer.de/GlobalAssetId/IntegrationTest99")
-                .assetType("AssetType99")
-                .assetKind(AssetKind.INSTANCE)
-                .administration(new DefaultAdministrativeInformation.Builder()
-                        .creator(new DefaultReference.Builder()
-                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                .keys(new DefaultKey.Builder()
-                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                        .value("http://anydomain.com/users/User99-1")
-                                        .build())
-                                .build())
-                        .version("12")
-                        .revision("25")
-                        .embeddedDataSpecifications(new DefaultEmbeddedDataSpecification.Builder()
-                                .dataSpecification(new DefaultReference.Builder()
-                                        .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                        .keys(new DefaultKey.Builder()
-                                                .type(KeyTypes.GLOBAL_REFERENCE)
-                                                .value("http://iosb.fraunhofer.de/IntegrationTest/AAS99/DataSpecificationIEC61360")
-                                                .build())
-                                        .build())
-                                .dataSpecificationContent(new DefaultDataSpecificationIec61360.Builder()
-                                        .preferredName(Arrays.asList(
-                                                new DefaultLangStringPreferredNameTypeIec61360.Builder().text("AAS 99 Spezifikation").language("de").build(),
-                                                new DefaultLangStringPreferredNameTypeIec61360.Builder().text("AAS 99 Specification").language("en-us").build()))
-                                        .dataType(DataTypeIec61360.REAL_MEASURE)
-                                        .definition(new DefaultLangStringDefinitionTypeIec61360.Builder().text("Dies ist eine Data Specification fuer Integration Test")
-                                                .language("de").build())
-                                        .definition(
-                                                new DefaultLangStringDefinitionTypeIec61360.Builder().text("This is a DataSpecification for integration testing purposes")
-                                                        .language("en-us").build())
-                                        .shortName(new DefaultLangStringShortNameTypeIec61360.Builder().text("Test Spezifikation").language("de").build())
-                                        .shortName(new DefaultLangStringShortNameTypeIec61360.Builder().text("Test Spec").language("en-us").build())
-                                        .unit("SpaceUnit")
-                                        .unitId(new DefaultReference.Builder()
-                                                .keys(new DefaultKey.Builder()
-                                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Units/TestUnit")
-                                                        .build())
-                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                                .build())
-                                        .sourceOfDefinition("http://iosb.fraunhofer.de/IntegrationTest/AAS99/DataSpec/ExampleDef")
-                                        .symbol("SU")
-                                        .valueFormat("string")
-                                        .value("TEST")
-                                        .valueList(new DefaultValueList.Builder()
-                                                .valueReferencePairs(new DefaultValueReferencePair.Builder()
-                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId")
-                                                        .valueId(new DefaultReference.Builder()
-                                                                .keys(new DefaultKey.Builder()
-                                                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ExampleValueId")
-                                                                        .build())
-                                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                                                .build())
-                                                        .build())
-                                                .valueReferencePairs(new DefaultValueReferencePair.Builder()
-                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId2")
-                                                        .valueId(new DefaultReference.Builder()
-                                                                .keys(new DefaultKey.Builder()
-                                                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                                                        .value("http://iosb.fraunhofer.de/IntegrationTest/ValueId/ExampleValueId2")
-                                                                        .build())
-                                                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                                                .build())
-                                                        .build())
-                                                .build())
-                                        .build())
-                                .build())
-                        .build())
-                .endpoints(new DefaultEndpoint.Builder()
-                        ._interface("http")
-                        .protocolInformation(new DefaultProtocolInformation.Builder()
-                                .endpointProtocol("http")
-                                .href("http://iosb.fraunhofer.de/IntegrationTest/Endpoints/AAS99")
-                                .endpointProtocolVersion(List.of("2.1"))
-                                .subprotocol("https")
-                                .subprotocolBody("any body")
-                                .subprotocolBodyEncoding("UTF-8")
-                                .securityAttributes(new DefaultSecurityAttributeObject.Builder()
-                                        .type(SecurityTypeEnum.NONE)
-                                        .key("")
-                                        .value("")
-                                        .build())
-                                .build())
-                        .build())
-                .extensions(new DefaultExtension.Builder()
-                        .name("AAS99 Extension Name")
-                        .value("AAS99 Extension Value")
-                        .semanticId(new DefaultReference.Builder()
-                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                .keys(new DefaultKey.Builder()
-                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SemanticId1")
-                                        .build())
-                                .build())
-                        .refersTo(new DefaultReference.Builder()
-                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                .keys(new DefaultKey.Builder()
-                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/RefersTo1")
-                                        .build())
-                                .build())
-                        .valueType(DataTypeDefXsd.STRING)
-                        .supplementalSemanticIds(new DefaultReference.Builder()
-                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                .keys(new DefaultKey.Builder()
-                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Extension99/SupplementalSemanticId1")
-                                        .build())
-                                .build())
-                        .build())
-                .submodelDescriptors(new DefaultSubmodelDescriptor.Builder()
-                        .id("http://iosb.fraunhofer.de/IntegrationTest/Submodel99-1")
-                        .idShort("Submodel-99-1")
-                        .administration(new DefaultAdministrativeInformation.Builder()
-                                .version("1")
-                                .revision("12")
-                                .build())
-                        .semanticId(new DefaultReference.Builder()
-                                .type(ReferenceTypes.EXTERNAL_REFERENCE)
-                                .keys(new DefaultKey.Builder()
-                                        .type(KeyTypes.GLOBAL_REFERENCE)
-                                        .value("http://iosb.fraunhofer.de/IntegrationTest/Submodel99-1/SemanticId")
-                                        .build())
-                                .build())
-                        .endpoints(new DefaultEndpoint.Builder()
-                                ._interface("http")
-                                .protocolInformation(new DefaultProtocolInformation.Builder()
-                                        .endpointProtocol("http")
-                                        .href("http://iosb.fraunhofer.de/Endpoints/Submodel99-1")
-                                        .endpointProtocolVersion(List.of("2.0"))
-                                        .build())
-                                .build())
-                        .build())
-                .build();
     }
 
 

--- a/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/ShellRegistryControllerIT.java
+++ b/service/src/test/java/de/fraunhofer/iosb/ilt/faaast/registry/service/ShellRegistryControllerIT.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -48,6 +49,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = App.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = "classpath:application-integrationtest.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ShellRegistryControllerIT extends AbstractShellRegistryControllerIT {
 
     @Test


### PR DESCRIPTION
This PR adds the AAS Part 2 Discovery API version 3.0.1 according to this specification: https://app.swaggerhub.com/apis/Plattform_i40/DiscoveryServiceSpecification/V3.0.1_SSP-001#/Asset%20Administration%20Shell%20Basic%20Discovery%20API/DeleteAllAssetLinksById

I have also refactored some of the IT classes to leverage common elements, specifically the ShellRegistryIT functions createAas, getAas and createURLWithPort.