### PR TITLE
feature: 2048 chars for subproto-body

### DIFF
--- a/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/EndpointConstraintHelper.java
+++ b/service/src/main/java/de/fraunhofer/iosb/ilt/faaast/registry/service/helper/EndpointConstraintHelper.java
@@ -56,7 +56,7 @@ public class EndpointConstraintHelper {
             CommonConstraintHelper.checkText(protocolInformation.getEndpointProtocol(), MAX_IDSHORT_LENGTH, false, "Endpoint Protocol");
             protocolInformation.getEndpointProtocolVersion().forEach(x -> CommonConstraintHelper.checkText(x, MAX_IDSHORT_LENGTH, false, "Endpoint Protocol Version"));
             CommonConstraintHelper.checkText(protocolInformation.getSubprotocol(), MAX_IDSHORT_LENGTH, false, "Subprotocol");
-            CommonConstraintHelper.checkText(protocolInformation.getSubprotocolBody(), MAX_IDSHORT_LENGTH, false, "Subprotocol Body");
+            CommonConstraintHelper.checkText(protocolInformation.getSubprotocolBody(), ConstraintHelper.MAX_STRING_2048_LENGTH, false, "Subprotocol Body");
             CommonConstraintHelper.checkText(protocolInformation.getSubprotocolBodyEncoding(), MAX_IDSHORT_LENGTH, false, "Subprotocol Body Encoding");
             checkSecurityAttributes(protocolInformation.getSecurityAttributes());
         }


### PR DESCRIPTION
In AAS Part 2 v3.1, the maximum allowed length for a `subprotocolBody` was expanded from 128 to 2048, which is useful for use-cases like [Catena-X](https://eclipse-tractusx.github.io/docs-kits/next/kits/digital-twin-kit/software-development-view/#registering-a-new-twin).

This change should not break compatibility with running instances of FA³ST registry.