### PR TITLE
fix: make Dockerfile use current version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM eclipse-temurin:17-jdk-alpine
-COPY service/target/service-0.1.0-SNAPSHOT.jar service-0.1.0-SNAPSHOT.jar
-ENTRYPOINT ["java","-jar","/service-0.1.0-SNAPSHOT.jar"]
+COPY service/target/service-1.2.0-SNAPSHOT.jar service-1.2.0-SNAPSHOT.jar
+ENTRYPOINT ["java","-jar","/service-1.2.0-SNAPSHOT.jar"]
+

--- a/release.sh
+++ b/release.sh
@@ -102,6 +102,7 @@ echo "Next: replacing version nubmers [enter]"
 read -s
 mvn versions:set -DgenerateBackupPoms=false -DnewVersion="${NEXTVERSION}"-SNAPSHOT
 sed -i 's/<tag>v'"${VERSION}"'<\/tag>/<tag>'"${NEXTBRANCH}"'<\/tag>/g' pom.xml
+sed -i 's/service-'"${VERSION}"'/service-'"${NEXTVERSION}"'/g' Dockerfile
 replaceValue "$README_FILE" "$TAG_DOWNLOAD_SNAPSHOT" "$README_LATEST_SNAPSHOT_VERSION_CONTENT"
 replaceValue "$INSTALLATION_FILE" "$TAG_DOWNLOAD_SNAPSHOT" "$INSTALLATION_LATEST_SNAPSHOT_VERSION_CONTENT"
 sed -i "2 i <!--start:${TAG_CHANGELOG_HEADER}-->\\n<!--end:${TAG_CHANGELOG_HEADER}-->" "$CHANGELOG_FILE"


### PR DESCRIPTION
Dockerfile is stuck on version 0.1.0-SNAPSHOT.

I've updated the Dockerfile as well as added a replacement command in the release.sh script